### PR TITLE
Specify java_buildpack_offline buildpack for java-spring-security

### DIFF
--- a/java-spring-security/manifest.yml
+++ b/java-spring-security/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: java-metric-registrar-demo
     buildpacks:
-      - java_buildpack
+      - java_buildpack_offline
     memory: 2GB
     disk_quota: 1GB
     path: build/libs/spring-security-example-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
- `java_buildpack_offline` is the default name of the buildpack in Tanzu Application Service
- We should also make the same change to the kotlin example, though this could be a separate PR as it appears to have other issues