### PR TITLE
Fix: java-spring-security SecurityConfig

### DIFF
--- a/java-spring-security/src/main/java/io/pivotal/metric_registrar/examples/spring_security/SecurityConfig.java
+++ b/java-spring-security/src/main/java/io/pivotal/metric_registrar/examples/spring_security/SecurityConfig.java
@@ -1,23 +1,29 @@
 package io.pivotal.metric_registrar.examples.spring_security;
 
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+@Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-                .requestMatchers(examplesRequestMatcher()).permitAll()
-                .and().authorizeRequests()
-                .requestMatchers((request) -> request.getServletPath().equals("/")).permitAll()
-                .and().authorizeRequests()
-                .requestMatchers(endpointRequestMatcher()).permitAll()
-                .and().authorizeRequests()
-                .anyRequest().denyAll();
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+            .requestMatchers(examplesRequestMatcher()).permitAll()
+            .and().authorizeRequests()
+            .requestMatchers((request) -> request.getServletPath().equals("/")).permitAll()
+            .and().authorizeRequests()
+            .requestMatchers(endpointRequestMatcher()).permitAll()
+            .and().authorizeRequests()
+            .anyRequest().denyAll();
+        return http.build();
     }
 
     private RequestMatcher endpointRequestMatcher() {
@@ -29,4 +35,5 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 request.getServletPath().equals("/custom_metric") ||
                 request.getServletPath().equals("/simple");
     }
+
 }


### PR DESCRIPTION
Replaces deprecated WebSecurityConfigurerAdapter use.

See
https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter for more info.

[#185196711](https://www.pivotaltracker.com/story/show/185196711)